### PR TITLE
メッセージ一覧画面のUIを作成

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:hoiqoo/messages_page.dart';
 import './saito.dart';
 import './oden.dart';
 import './takasu.dart';
@@ -53,14 +52,6 @@ class _MyHomePageState extends State<MyHomePage> {
             const Nav(page: Oden(label: 'おでん'), label: "おでん"),
             const Nav(page: Takasu(label: '高須'), label: "高須"),
             const Nav(page: Fukushin(label: 'フクシン'), label: "フクシン"),
-            // messages pageに移動するためのボタン
-            // 後で削除する
-            ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                      MaterialPageRoute(builder: (context) => MessagesPage()));
-                },
-                child: Text('messages page')),
           ],
         ),
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:hoiqoo/messages_page.dart';
 import './saito.dart';
 import './oden.dart';
 import './takasu.dart';
@@ -45,12 +46,21 @@ class _MyHomePageState extends State<MyHomePage> {
           children: <Widget>[
             Container(
               margin: const EdgeInsets.all(40),
-              child: const Text('hoiqoo スキルテスト', style: TextStyle(fontSize: 24)),
+              child:
+                  const Text('hoiqoo スキルテスト', style: TextStyle(fontSize: 24)),
             ),
             const Nav(page: Saito(label: '齋藤'), label: "齋藤"),
             const Nav(page: Oden(label: 'おでん'), label: "おでん"),
             const Nav(page: Takasu(label: '高須'), label: "高須"),
             const Nav(page: Fukushin(label: 'フクシン'), label: "フクシン"),
+            // messages pageに移動するためのボタン
+            // 後で削除する
+            ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                      MaterialPageRoute(builder: (context) => MessagesPage()));
+                },
+                child: Text('messages page')),
           ],
         ),
       ),
@@ -60,7 +70,9 @@ class _MyHomePageState extends State<MyHomePage> {
 
 class Nav extends StatelessWidget {
   const Nav({
-    Key? key, required this.page, required this.label,
+    Key? key,
+    required this.page,
+    required this.label,
   }) : super(key: key);
 
   final Widget page;
@@ -70,14 +82,14 @@ class Nav extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        Navigator.push(context, MaterialPageRoute(builder: (context){
+        Navigator.push(context, MaterialPageRoute(builder: (context) {
           return page;
         }));
       },
       child: Container(
         margin: const EdgeInsets.all(20),
         width: MediaQuery.of(context).size.width * 0.8,
-        height: MediaQuery.of(context).size.width* 0.15,
+        height: MediaQuery.of(context).size.width * 0.15,
         alignment: Alignment.center,
         decoration: BoxDecoration(
           border: Border.all(

--- a/lib/messages_page.dart
+++ b/lib/messages_page.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
-// メッセージ一覧ページ
-class MessagesPage extends StatelessWidget {
-  const MessagesPage({super.key});
+// チャットルーム 一覧ページ
+class ChatRoomsPage extends StatelessWidget {
+  const ChatRoomsPage({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -15,31 +15,31 @@ class MessagesPage extends StatelessWidget {
       ),
       body: Column(
         children: const [
-          MessagesList(), //メッセージ一覧
+          ChatRoomsList(), //メッセージ一覧
         ],
       ),
     );
   }
 }
 
-// メッセージのリスト
-// riverpodでメッセージ一覧を取得し、メッセージのリストを作成
-class MessagesList extends StatelessWidget {
-  const MessagesList({super.key});
+// チャットルームのリスト
+// riverpodでチャットルーム一覧を取得し、チャットルームのリストを作成
+class ChatRoomsList extends StatelessWidget {
+  const ChatRoomsList({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // Messageデータを取得（本番では、riverpodで取得する）
-    // 今は仮のMessageデータを作成
-    final List<MockMessage> messages = <MockMessage>[
-      MockMessage(
+    // ChatRoomデータを取得（本番では、riverpodで取得する）
+    // 今は仮のChatRoomデータを作成
+    final List<MockChatRoom> chatRooms = <MockChatRoom>[
+      MockChatRoom(
         id: 0,
         image: 'assets/images/icon.png',
         name: 'あおぞら保育園',
         content: '最寄りは初台駅で良いでしょうか',
         timestamp: DateTime.now().millisecondsSinceEpoch.toString(),
       ),
-      MockMessage(
+      MockChatRoom(
         id: 1,
         image: 'assets/images/icon.png',
         name: 'にじいろ保育園',
@@ -47,7 +47,7 @@ class MessagesList extends StatelessWidget {
         timestamp:
             (DateTime.now().millisecondsSinceEpoch - 86400000).toString(),
       ),
-      MockMessage(
+      MockChatRoom(
         id: 2,
         image: 'assets/images/icon.png',
         name: 'おひさま保育園',
@@ -55,7 +55,7 @@ class MessagesList extends StatelessWidget {
         timestamp:
             (DateTime.now().millisecondsSinceEpoch - 17280000).toString(),
       ),
-      MockMessage(
+      MockChatRoom(
         id: 3,
         image: 'assets/images/icon.png',
         name: 'ほしぞら保育園',
@@ -67,38 +67,38 @@ class MessagesList extends StatelessWidget {
 
     return Expanded(
       child: ListView.builder(
-        itemCount: messages.length,
+        itemCount: chatRooms.length,
         itemBuilder: (BuildContext context, int index) {
-          return MessageBuildItem(message: messages[index]);
+          return ChatRoomBuildItem(chatRoom: chatRooms[index]);
         },
       ),
     );
   }
 }
 
-// メッセージ(ListTile)
-// メッセージモデルを引数に取ってItemを構築する
-// ListTileをタップしたら、メッセージ詳細画面に遷移したい
-class MessageBuildItem extends StatelessWidget {
-  const MessageBuildItem({super.key, required this.message});
+// チャットルーム(ListTile)
+// チャットルームモデルを引数に取ってItemを構築する
+// ListTileをタップしたら、チャットルーム詳細画面に遷移したい
+class ChatRoomBuildItem extends StatelessWidget {
+  const ChatRoomBuildItem({super.key, required this.chatRoom});
 
-  final MockMessage message;
+  final MockChatRoom chatRoom;
 
   @override
   Widget build(BuildContext context) {
     return ListTile(
       // [TODO]:keyつけたい
-      leading: Image.asset(message.image),
+      leading: Image.asset(chatRoom.image),
       title: Text(
-        message.name,
+        chatRoom.name,
       ),
       subtitle: Text(
-        message.content,
+        chatRoom.content,
         maxLines: 2,
         overflow: TextOverflow.ellipsis,
       ),
       trailing: Text(
-        getTime(message.timestamp),
+        formatTimestamp(chatRoom.timestamp),
       ),
       isThreeLine: true,
     );
@@ -106,13 +106,13 @@ class MessageBuildItem extends StatelessWidget {
 }
 
 // タイムスタンプをフォーマットして、
-// メッセージ一覧に表示する日付の文字列を返す
+// チャットルーム一覧に表示する日付の文字列を返す
 // (例)
 // ・24時間以内のメッセージ -> 10:24AM
 // ・24時間〜48時間のメッセージ -> 昨日
 // ・48時間〜１年のメッセージ -> 11月15日
 // ・１年〜のメッセージ -> 2021年5月15日
-String getTime(String timestamp) {
+String formatTimestamp(String timestamp) {
   DateTime dateTime = DateTime.fromMillisecondsSinceEpoch(int.parse(timestamp));
   int millisecondsFromNow = dateTime
       .difference(DateTime.now())
@@ -137,10 +137,10 @@ String getTime(String timestamp) {
       .format(DateTime.fromMillisecondsSinceEpoch(int.parse(timestamp)));
 }
 
-// メッセージクラス(仮)
-// メッセージ一覧に表示するメッセージに必要最低限の要素を定義
-class MockMessage {
-  const MockMessage({
+// チャットルームクラス(仮)
+// チャットルーム一覧に表示するチャットルームに必要最低限の要素を定義
+class MockChatRoom {
+  const MockChatRoom({
     required this.id,
     required this.image,
     required this.name,

--- a/lib/messages_page.dart
+++ b/lib/messages_page.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+// メッセージ一覧ページ
+class MessagesPage extends StatelessWidget {
+  const MessagesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("メッセージ一覧", style: TextStyle(fontSize: 18)),
+        centerTitle: true,
+        elevation: 0.5,
+      ),
+      body: Column(
+        children: const [
+          MessagesList(), //メッセージ一覧
+        ],
+      ),
+    );
+  }
+}
+
+// メッセージのリスト
+// riverpodでメッセージ一覧を取得し、メッセージのリストを作成
+class MessagesList extends StatelessWidget {
+  const MessagesList({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // Messageデータを取得（本番では、riverpodで取得する）
+    // 今は仮のMessageデータを作成
+    final List<MockMessage> messages = <MockMessage>[
+      MockMessage(
+        id: 0,
+        image: 'assets/images/icon.png',
+        name: 'あおぞら保育園',
+        content: '最寄りは初台駅で良いでしょうか',
+        timestamp: DateTime.now().millisecondsSinceEpoch.toString(),
+      ),
+      MockMessage(
+        id: 1,
+        image: 'assets/images/icon.png',
+        name: 'にじいろ保育園',
+        content: 'こんにちは！よろしくお願いします！',
+        timestamp:
+            (DateTime.now().millisecondsSinceEpoch - 86400000).toString(),
+      ),
+      MockMessage(
+        id: 2,
+        image: 'assets/images/icon.png',
+        name: 'おひさま保育園',
+        content: '初めまして。おひさま保育園の田中です。',
+        timestamp:
+            (DateTime.now().millisecondsSinceEpoch - 17280000).toString(),
+      ),
+      MockMessage(
+        id: 3,
+        image: 'assets/images/icon.png',
+        name: 'ほしぞら保育園',
+        content: '初めまして。よろしくお願いします。早速ですが希望のシフトの確認をさせてください。',
+        timestamp:
+            (DateTime.now().millisecondsSinceEpoch - 31536000000).toString(),
+      ),
+    ];
+
+    return Expanded(
+      child: ListView.builder(
+        itemCount: messages.length,
+        itemBuilder: (BuildContext context, int index) {
+          return MessageBuildItem(message: messages[index]);
+        },
+      ),
+    );
+  }
+}
+
+// メッセージ(ListTile)
+// メッセージモデルを引数に取ってItemを構築する
+// ListTileをタップしたら、メッセージ詳細画面に遷移したい
+class MessageBuildItem extends StatelessWidget {
+  const MessageBuildItem({super.key, required this.message});
+
+  final MockMessage message;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      // [TODO]:keyつけたい
+      leading: Image.asset(message.image),
+      title: Text(
+        message.name,
+      ),
+      subtitle: Text(
+        message.content,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: Text(
+        getTime(message.timestamp),
+      ),
+      isThreeLine: true,
+    );
+  }
+}
+
+// タイムスタンプをフォーマットして、
+// メッセージ一覧に表示する日付の文字列を返す
+// (例)
+// ・24時間以内のメッセージ -> 10:24AM
+// ・24時間〜48時間のメッセージ -> 昨日
+// ・48時間〜１年のメッセージ -> 11月15日
+// ・１年〜のメッセージ -> 2021年5月15日
+String getTime(String timestamp) {
+  DateTime dateTime = DateTime.fromMillisecondsSinceEpoch(int.parse(timestamp));
+  int millisecondsFromNow = dateTime
+      .difference(DateTime.now())
+      .inMilliseconds
+      .abs(); //ミリ秒数（現在時刻から何ミリ秒前のメッセージなのか）
+  DateFormat format;
+
+  if (millisecondsFromNow <= 86400000) {
+    //24時間以内
+    format = DateFormat.jm();
+  } else if (millisecondsFromNow <= 172800000) {
+    //48時間以内
+    return '昨日';
+  } else if (millisecondsFromNow <= 31536000000) {
+    //1年以内
+    format = DateFormat.MMMMd();
+  } else {
+    //1年より前
+    format = DateFormat.yMd();
+  }
+  return format
+      .format(DateTime.fromMillisecondsSinceEpoch(int.parse(timestamp)));
+}
+
+// メッセージクラス(仮)
+// メッセージ一覧に表示するメッセージに必要最低限の要素を定義
+class MockMessage {
+  const MockMessage({
+    required this.id,
+    required this.image,
+    required this.name,
+    required this.content,
+    required this.timestamp,
+  });
+
+  final int id;
+  final String image; //アイコン画像のパス
+  final String name; //名前　(例)あおぞら保育園
+  final String content; //メッセージ文
+  final String timestamp; //時刻
+}

--- a/lib/takasu.dart
+++ b/lib/takasu.dart
@@ -1,6 +1,7 @@
 // CORE
 import 'dart:core';
 import 'package:flutter/material.dart';
+import 'package:hoiqoo/messages_page.dart';
 
 class Takasu extends StatefulWidget {
   const Takasu({Key? key, required this.label}) : super(key: key);
@@ -29,6 +30,15 @@ class _TakasuState extends State<Takasu> {
             const Text("テスト"),
             // TODO: 自分のslackアイコンを画面横幅の半分の大きさで表示してください
             Image.asset("assets/images/icon.png"),
+            // messages pageに移動するためのボタン
+            // 後で削除する
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                    MaterialPageRoute(builder: (context) => MessagesPage()));
+              },
+              child: const Text('messages page'),
+            ),
           ],
         ),
       ),

--- a/lib/takasu.dart
+++ b/lib/takasu.dart
@@ -16,20 +16,20 @@ class _TakasuState extends State<Takasu> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-          title: Text(widget.label, style: const TextStyle(fontSize: 18)),
-          centerTitle: true,
-          elevation: 0.5,
+        title: Text(widget.label, style: const TextStyle(fontSize: 18)),
+        centerTitle: true,
+        elevation: 0.5,
       ),
       // TODO: 画面の背景色をグレーにしてください
       body: Center(
         child: Column(
           // TODO: childrenに含まれる各要素を画面の上下左右中央に配置してください
-            children: [
-              // TODO: 自分の名前を今より大きく表示してください
-              const Text("テスト"),
-              // TODO: 自分のslackアイコンを画面横幅の半分の大きさで表示してください
-              Image.asset("assets/images/icon.png"),
-            ]
+          children: [
+            // TODO: 自分の名前を今より大きく表示してください
+            const Text("テスト"),
+            // TODO: 自分のslackアイコンを画面横幅の半分の大きさで表示してください
+            Image.asset("assets/images/icon.png"),
+          ],
         ),
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -67,6 +67,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.0"
   lints:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  intl: #DateFormat
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
## やったこと

- メッセージ一覧画面のUIを作成

- モックデータの作成

## スクリーンショット
![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-12-03 at 20 59 06](https://user-images.githubusercontent.com/65100972/205440579-99bf817f-5420-40f9-ae62-830082838492.png)


## 動作確認
Simulator (iPhone SE (3rd))で確認
* [x] メッセージ一覧画面が正常に表示される

## その他
レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

-  おでんさんと同様、「高須（スキルテスト画面）」＞「メッセージ一覧画面」に遷移できるようにしました。

-  メッセージの日付の部分の日本語化対応がまだできていません。

